### PR TITLE
Fix double slash when shortening link

### DIFF
--- a/src/Qfeed/components/DiscussionPage.jsx
+++ b/src/Qfeed/components/DiscussionPage.jsx
@@ -45,7 +45,7 @@ const DiscussionPage = ({ match, history }) => {
   };
 
   const getShortLink = (id) => {
-    const original_url = process.env.REACT_APP_URL + `/qfeed/${id}`;
+    const original_url = process.env.REACT_APP_URL + `qfeed/${id}`;
     let questionsClone = [...questions];
     const question_index = questions.findIndex(
       (question) => question.id === id

--- a/src/Qfeed/components/Question.jsx
+++ b/src/Qfeed/components/Question.jsx
@@ -44,7 +44,7 @@ const Question = (props) => {
   };
 
   const getShortLink = (id) => {
-    const original_url = process.env.REACT_APP_URL + `/qfeed/${id}`;
+    const original_url = process.env.REACT_APP_URL + `qfeed/${id}`;
     const questionsClone = [...questions];
     const question_index = questions.findIndex(
       (question) => question.id === id


### PR DESCRIPTION
This PR resolves #268 

- [x] Remove the double slash in a question link before shortening it. 